### PR TITLE
Add pre-merge and post-merge hooks

### DIFF
--- a/GitObjectDb/Git/Hooks/GitHooks.cs
+++ b/GitObjectDb/Git/Hooks/GitHooks.cs
@@ -18,9 +18,19 @@ namespace GitObjectDb.Git.Hooks
         public event EventHandler<CommitStartedEventArgs> CommitStarted;
 
         /// <summary>
-        /// Occurs when a commit is about to be made.
+        /// Occurs when a commit has been completed successfully.
         /// </summary>
         public event EventHandler<CommitCompletedEventArgs> CommitCompleted;
+
+        /// <summary>
+        /// Occurs when a merge is about to be processed.
+        /// </summary>
+        public event EventHandler<MergeStartedEventArgs> MergeStarted;
+
+        /// <summary>
+        /// Occurs when a merge has been completed successfully.
+        /// </summary>
+        public event EventHandler<MergeCompletedEventArgs> MergeCompleted;
 
         /// <summary>
         /// Called when a commit is about to be started.
@@ -41,7 +51,7 @@ namespace GitObjectDb.Git.Hooks
         }
 
         /// <summary>
-        /// Called when a commit is about to be started.
+        /// Called when a commit has been completed successfully.
         /// </summary>
         /// <param name="changes">The changes.</param>
         /// <param name="message">The message.</param>
@@ -55,6 +65,29 @@ namespace GitObjectDb.Git.Hooks
 
             var args = new CommitCompletedEventArgs(changes, message, commitId);
             CommitCompleted?.Invoke(this, args);
+        }
+
+        /// <summary>
+        /// Called when a merge is about to be processed.
+        /// </summary>
+        /// <param name="changes">The changes.</param>
+        /// <returns>The <see cref="CancelEventArgs"/>.</returns>
+        internal bool OnMergeStarted(MetadataTreeChanges changes)
+        {
+            var args = new MergeStartedEventArgs(changes);
+            MergeStarted?.Invoke(this, args);
+            return !args.Cancel;
+        }
+
+        /// <summary>
+        /// Called when a merge has been completed successfully.
+        /// </summary>
+        /// <param name="changes">The changes.</param>
+        /// <param name="commitId">The commit identifier.</param>
+        internal void OnMergeCompleted(MetadataTreeChanges changes, ObjectId commitId)
+        {
+            var args = new MergeCompletedEventArgs(changes, commitId);
+            MergeCompleted?.Invoke(this, args);
         }
     }
 }

--- a/GitObjectDb/Git/Hooks/MergeCompletedEventArgs.cs
+++ b/GitObjectDb/Git/Hooks/MergeCompletedEventArgs.cs
@@ -6,21 +6,19 @@ using System.ComponentModel;
 namespace GitObjectDb.Git.Hooks
 {
     /// <summary>
-    /// Provides data for a post-commit event.
+    /// Provides data for a post-merge event.
     /// </summary>
-    public class CommitCompletedEventArgs : EventArgs
+    public class MergeCompletedEventArgs : EventArgs
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="CommitCompletedEventArgs"/> class.
+        /// Initializes a new instance of the <see cref="MergeCompletedEventArgs"/> class.
         /// </summary>
         /// <param name="changes">The changes.</param>
-        /// <param name="message">The message.</param>
         /// <param name="commitId">The commit identifier.</param>
         /// <exception cref="ArgumentNullException">message</exception>
-        public CommitCompletedEventArgs(MetadataTreeChanges changes, string message, ObjectId commitId)
+        public MergeCompletedEventArgs(MetadataTreeChanges changes, ObjectId commitId)
         {
             Changes = changes ?? throw new ArgumentNullException(nameof(changes));
-            Message = message ?? throw new ArgumentNullException(nameof(message));
             CommitId = commitId ?? throw new ArgumentNullException(nameof(commitId));
         }
 
@@ -28,11 +26,6 @@ namespace GitObjectDb.Git.Hooks
         /// Gets the changes.
         /// </summary>
         public MetadataTreeChanges Changes { get; }
-
-        /// <summary>
-        /// Gets the message.
-        /// </summary>
-        public string Message { get; }
 
         /// <summary>
         /// Gets the commit identifier.

--- a/GitObjectDb/Git/Hooks/MergeStartedEventArgs.cs
+++ b/GitObjectDb/Git/Hooks/MergeStartedEventArgs.cs
@@ -1,0 +1,28 @@
+using GitObjectDb.Models.Compare;
+using System;
+using System.ComponentModel;
+
+namespace GitObjectDb.Git.Hooks
+{
+    /// <summary>
+    /// Provides data for a pre-merge event.
+    /// </summary>
+    /// <seealso cref="System.ComponentModel.CancelEventArgs" />
+    public class MergeStartedEventArgs : CancelEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MergeStartedEventArgs"/> class.
+        /// </summary>
+        /// <param name="changes">The changes.</param>
+        /// <exception cref="ArgumentNullException">message</exception>
+        public MergeStartedEventArgs(MetadataTreeChanges changes)
+        {
+            Changes = changes ?? throw new ArgumentNullException(nameof(changes));
+        }
+
+        /// <summary>
+        /// Gets the changes.
+        /// </summary>
+        public MetadataTreeChanges Changes { get; }
+    }
+}


### PR DESCRIPTION
Add hooks to resolve events when a merge is processed on a repository.