### PR TITLE
Only compare node reference path

### DIFF
--- a/src/GitObjectDb.Api.GraphQL/GitObjectDb.Api.GraphQL.csproj
+++ b/src/GitObjectDb.Api.GraphQL/GitObjectDb.Api.GraphQL.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Description>Provides GraphQL endpoints for querying and mutating GitObjectDb repository.</Description>
     <PackageType>Dependency</PackageType>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GitObjectDb.Api.OData/GitObjectDb.Api.OData.csproj
+++ b/src/GitObjectDb.Api.OData/GitObjectDb.Api.OData.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Description>Provides OData endpoints for querying GitObjectDb repository.</Description>
     <PackageType>Dependency</PackageType>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GitObjectDb.Api.ProtoBuf.Model/GitObjectDb.Api.ProtoBuf.Model.csproj
+++ b/src/GitObjectDb.Api.ProtoBuf.Model/GitObjectDb.Api.ProtoBuf.Model.csproj
@@ -8,6 +8,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Description>Provides ProtoBuf data model to handle GitObjectDb Grpc requests.</Description>
     <PackageType>Dependency</PackageType>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GitObjectDb.Api.ProtoBuf/GitObjectDb.Api.ProtoBuf.csproj
+++ b/src/GitObjectDb.Api.ProtoBuf/GitObjectDb.Api.ProtoBuf.csproj
@@ -8,6 +8,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Description>Provides Grpc endpoints for querying GitObjectDb repository.</Description>
     <PackageType>Dependency</PackageType>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GitObjectDb.SystemTextJson/GitObjectDb.SystemTextJson.csproj
+++ b/src/GitObjectDb.SystemTextJson/GitObjectDb.SystemTextJson.csproj
@@ -10,6 +10,8 @@
     <WarningsAsErrors />
     <Description>Provides a Json serialization based on System.Text.Json for GitObjectDb nodes.</Description>
     <PackageType>Dependency</PackageType>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GitObjectDb.YamlDotNet/GitObjectDb.YamlDotNet.csproj
+++ b/src/GitObjectDb.YamlDotNet/GitObjectDb.YamlDotNet.csproj
@@ -10,6 +10,8 @@
     <WarningsAsErrors />
     <Description>Provides a Yaml serialization based on YamlDotNet for GitObjectDb nodes.</Description>
     <PackageType>Dependency</PackageType>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GitObjectDb/Comparison/Comparer.cs
+++ b/src/GitObjectDb/Comparison/Comparer.cs
@@ -1,11 +1,8 @@
 using GitObjectDb.Internal.Queries;
 using KellermanSoftware.CompareNetObjects;
 using LibGit2Sharp;
-using Microsoft.Extensions.Caching.Memory;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace GitObjectDb.Comparison;
@@ -18,10 +15,6 @@ internal class Comparer : IComparer, IComparerInternal
     {
         _nodeLoader = nodeLoader;
     }
-
-    internal static IEnumerable<PropertyInfo> GetProperties(Type type, ComparisonPolicy policy) =>
-        type.GetTypeInfo().GetProperties(BindingFlags.Instance | BindingFlags.Public)
-        .Where(p => p.CanRead && p.CanWrite && !policy.IgnoredProperties.Contains(p) && p.Name != nameof(TreeItem.Path));
 
     public ComparisonResult Compare(TreeItem? expectedObject, TreeItem? actualObject, ComparisonPolicy policy)
     {

--- a/src/GitObjectDb/Comparison/NodeComparerLimitedToPath.cs
+++ b/src/GitObjectDb/Comparison/NodeComparerLimitedToPath.cs
@@ -1,0 +1,128 @@
+using Fasterflect;
+using GitObjectDb.Tools;
+using KellermanSoftware.CompareNetObjects;
+using KellermanSoftware.CompareNetObjects.TypeComparers;
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace GitObjectDb.Comparison;
+internal class NodeComparerLimitedToPath : ClassComparer
+{
+    private static readonly ConcurrentDictionary<Type, IEnumerable<PropertyInfo>> _cache = new();
+
+    public NodeComparerLimitedToPath(RootComparer rootComparer)
+        : base(rootComparer)
+    {
+    }
+
+    public override bool IsTypeMatch(Type? type1, Type? type2) =>
+        (type1 is not null && GetNodeReferences(type1).Any()) &&
+        (type2 is not null && GetNodeReferences(type2).Any());
+
+    public override void CompareType(CompareParms parms)
+    {
+        base.CompareType(parms);
+
+        CompareReferencedNodePathChanges(parms);
+    }
+
+    private void CompareReferencedNodePathChanges(CompareParms parms)
+    {
+        try
+        {
+            parms.Result.AddParent(parms.Object1);
+            parms.Result.AddParent(parms.Object2);
+            if (parms.Object1 is IEnumerable || parms.Object1 != parms.Object2)
+            {
+                var type1 = parms.Object1.GetType();
+                var type2 = parms.Object2.GetType();
+                if (!ExcludeLogic.ShouldExcludeClass(parms.Config, type1, type2))
+                {
+                    parms.Object1Type = type1;
+                    parms.Object2Type = type2;
+                    PerformReferencedNodeCompareProperties(parms);
+                }
+            }
+        }
+        finally
+        {
+            parms.Result.RemoveParent(parms.Object1);
+            parms.Result.RemoveParent(parms.Object2);
+        }
+    }
+
+    private void PerformReferencedNodeCompareProperties(CompareParms parms)
+    {
+        var currentProperties1 = GetNodeReferences(parms.Object1Type);
+        var currentProperties2 = GetNodeReferences(parms.Object2Type);
+        foreach (var property in currentProperties1)
+        {
+            CompareReferencedNodeProperty(parms, property, currentProperties2);
+            if (parms.Result.ExceededDifferences)
+            {
+                break;
+            }
+        }
+    }
+
+    private void CompareReferencedNodeProperty(CompareParms parms, PropertyInfo info, IEnumerable<PropertyInfo> object2Properties)
+    {
+        if (!info.CanRead || (!parms.Config.CompareReadOnly && !info.CanWrite))
+        {
+            return;
+        }
+        var secondObjectInfo = GetSecondObjectInfo(info, object2Properties);
+        if ((parms.Config.IgnoreObjectTypes || parms.Config.IgnoreConcreteTypes) &&
+            secondObjectInfo is null &&
+            parms.Config.IgnoreMissingProperties)
+        {
+            return;
+        }
+        if (info.PropertyType.IsNodeEnumerable(out var _))
+        {
+            var values1 = (IEnumerable<Node>?)Reflect.PropertyGetter(info).Invoke(parms.Object1);
+            var values2 = (IEnumerable<Node>?)(secondObjectInfo is not null ? Reflect.PropertyGetter(secondObjectInfo).Invoke(parms.Object2) : null);
+            RootComparer.Compare(new CompareParms
+            {
+                Result = parms.Result,
+                Config = parms.Config,
+                ParentObject1 = parms.Object1,
+                ParentObject2 = parms.Object2,
+                Object1 = values1?.Select(n => n.Path),
+                Object2 = values2?.Select(n => n.Path),
+                BreadCrumb = AddBreadCrumb(parms.Config, parms.BreadCrumb, info.Name),
+                Object1DeclaredType = typeof(IEnumerable<DataPath>),
+                Object2DeclaredType = typeof(IEnumerable<DataPath>),
+            });
+        }
+        else
+        {
+            var node1 = (Node?)Reflect.PropertyGetter(info).Invoke(parms.Object1);
+            var node2 = (Node?)(secondObjectInfo is not null ? Reflect.PropertyGetter(secondObjectInfo).Invoke(parms.Object2) : null);
+            RootComparer.Compare(new CompareParms
+            {
+                Result = parms.Result,
+                Config = parms.Config,
+                ParentObject1 = parms.Object1,
+                ParentObject2 = parms.Object2,
+                Object1 = node1?.Path,
+                Object2 = node2?.Path,
+                BreadCrumb = AddBreadCrumb(parms.Config, parms.BreadCrumb, info.Name),
+                Object1DeclaredType = typeof(DataPath),
+                Object2DeclaredType = typeof(DataPath),
+            });
+        }
+    }
+
+    private static PropertyInfo? GetSecondObjectInfo(PropertyInfo info, IEnumerable<PropertyInfo> object2Properties) =>
+        object2Properties.FirstOrDefault(p => p.Name == info.Name);
+
+    private static IEnumerable<PropertyInfo> GetNodeReferences(Type type) => _cache.GetOrAdd(type, static t =>
+        (from p in t.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+         where p.PropertyType.IsNode() || p.PropertyType.IsNodeEnumerable(out var _)
+         select p).ToList());
+}

--- a/src/GitObjectDb/GitObjectDb.csproj
+++ b/src/GitObjectDb/GitObjectDb.csproj
@@ -11,6 +11,8 @@
     <Description>GitObjectDb is designed to simplify the configuration management versioning. It does so by removing the need for hand-coding the commands needed to interact with Git. The Git repository is used as a pure database as the files containing the serialized copy of the objects are never fetched in the filesystem. GitObjectDb only uses the blob storage provided by Git.</Description>
     <PackageId>GitObjectDb</PackageId>
     <PackageType>Dependency</PackageType>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/GitObjectDb.Api.OData.Tests/GitObjectDbApiFixture.cs
+++ b/src/tests/GitObjectDb.Api.OData.Tests/GitObjectDbApiFixture.cs
@@ -1,3 +1,4 @@
+using GitObjectDb.Tests;
 using GitObjectDb.Tests.Assets.Tools;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
@@ -10,37 +11,6 @@ namespace GitObjectDb.Api.OData.Tests;
 [SetUpFixture]
 public class GitObjectDbApiFixture
 {
-    private const string TempPath = @"C:\Temp";
-
-    private static readonly string _workDirectory =
-        Directory.Exists(TempPath) ?
-        TempPath :
-        Path.GetDirectoryName(AssemblyHelper.GetAssemblyPath(Assembly.GetExecutingAssembly()));
-
-    public static string SoftwareBenchmarkRepositoryPath { get; } =
-        Path.Combine(_workDirectory, "Repos", "Data", "Software", "Benchmark");
-
-    public static string TempRepoPath { get; } =
-        Path.Combine(_workDirectory, "TempRepos");
-
     [OneTimeSetUp]
-    public void RestoreRepositories()
-    {
-        if (!Directory.Exists(SoftwareBenchmarkRepositoryPath))
-        {
-            ZipFile.ExtractToDirectory(
-                Path.Combine(
-                    TestContext.CurrentContext.TestDirectory,
-                    "Assets", "Data", "Software", "Benchmark.zip"),
-                SoftwareBenchmarkRepositoryPath);
-        }
-    }
-
-    [OneTimeTearDown]
-    public void DeleteTempPath() => DeleteTempPathImpl();
-
-    private static void DeleteTempPathImpl()
-    {
-        DirectoryUtils.Delete(TempRepoPath, true);
-    }
+    public void RestoreRepositories() => new GitObjectDbFixture().RestoreRepositories();
 }

--- a/src/tests/GitObjectDb.SystemTextJson.Tests/Customization/ReferenceCustomization.cs
+++ b/src/tests/GitObjectDb.SystemTextJson.Tests/Customization/ReferenceCustomization.cs
@@ -1,6 +1,5 @@
 using AutoFixture;
 using GitObjectDb.Model;
-using GitObjectDb.Tests;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;

--- a/src/tests/GitObjectDb.Tests/GitObjectDbFixture.cs
+++ b/src/tests/GitObjectDb.Tests/GitObjectDbFixture.cs
@@ -1,11 +1,8 @@
 using GitObjectDb.Tests.Assets.Tools;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
-using System;
-using System.Globalization;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Reflection;
 
 namespace GitObjectDb.Tests;
@@ -13,12 +10,8 @@ namespace GitObjectDb.Tests;
 [SetUpFixture]
 public class GitObjectDbFixture
 {
-    private const string TempPath = @"C:\Temp";
-
     private static readonly object _sync = new();
     private static readonly string _workDirectory =
-        Directory.Exists(TempPath) ?
-        TempPath :
         Path.GetDirectoryName(AssemblyHelper.GetAssemblyPath(Assembly.GetExecutingAssembly()));
 
     public static string SoftwareBenchmarkRepositoryPath { get; } =
@@ -31,21 +24,11 @@ public class GitObjectDbFixture
     public static string GetAvailableFolderPath()
 #pragma warning restore NUnit1028 // The non-test method is public
     {
-        var i = 1;
-        string result;
-        lock (_sync)
-        {
-            while (true)
-            {
-                result = Path.Combine(TempRepoPath, i.ToString("D4", CultureInfo.InvariantCulture));
-                if (!Directory.Exists(result))
-                {
-                    Directory.CreateDirectory(result);
-                    return result;
-                }
-                i++;
-            }
-        }
+        var test = TestContext.CurrentContext.Test;
+        var result = Path.Combine(TempRepoPath, $"{test.MethodName}-{test.ID}");
+        DirectoryUtils.Delete(result, true);
+        Directory.CreateDirectory(result);
+        return result;
     }
 
     [OneTimeSetUp]
@@ -63,8 +46,4 @@ public class GitObjectDbFixture
             }
         }
     }
-
-    [OneTimeSetUp]
-    [OneTimeTearDown]
-    public void DeleteTempPath() => DirectoryUtils.Delete(TempRepoPath, true);
 }

--- a/src/tests/GitObjectDb.Tests/RemoteResourceTests.cs
+++ b/src/tests/GitObjectDb.Tests/RemoteResourceTests.cs
@@ -11,14 +11,14 @@ using System.Text;
 
 namespace GitObjectDb.Tests;
 
-public class RemoteResourceTests
+public class RemoteResourceTests : DisposeArguments
 {
     [Test]
     [AutoDataCustomizations(typeof(DefaultServiceProviderCustomization), typeof(SoftwareCustomization))]
     public void AddRemoteResourceRepository(IConnection connection, Application application, string content, string message, Signature committer)
     {
         // Arrange
-        var (path, tip) = CreateResourceRepository(content, message, committer);
+        var (path, tip) = CreateResourceRepository(connection, content, message, committer);
 
         // Act
         var applicationWithLinkedResources = application with
@@ -44,7 +44,7 @@ public class RemoteResourceTests
     public void StageAndAddRemoteResourceRepository(IConnection connection, Application application, string content, string message, Signature committer)
     {
         // Arrange
-        var (path, tip) = CreateResourceRepository(content, message, committer);
+        var (path, tip) = CreateResourceRepository(connection, content, message, committer);
 
         // Act
         var applicationWithLinkedResources = application with
@@ -70,7 +70,7 @@ public class RemoteResourceTests
     public void ThrowIfWrongCommitId(IConnection connection, Application application, string content, string message, Signature committer)
     {
         // Arrange
-        var (path, tip) = CreateResourceRepository(content, message, committer);
+        var (path, tip) = CreateResourceRepository(connection, content, message, committer);
 
         // Act
         var applicationWithLinkedResources = application with
@@ -94,7 +94,7 @@ public class RemoteResourceTests
     public void CannotMixEmbeddedAndRemoteResources(IConnection connection, Application application, string content, string message, Signature committer)
     {
         // Arrange
-        var (path, tip) = CreateResourceRepository(content, message, committer);
+        var (path, tip) = CreateResourceRepository(connection, content, message, committer);
 
         // Act
         var applicationWithLinkedResources = application with
@@ -117,9 +117,9 @@ public class RemoteResourceTests
             () => changes.Commit(new(message, committer, committer)));
     }
 
-    private static (string Path, string Tip) CreateResourceRepository(string content, string message, Signature committer)
+    private static (string Path, string Tip) CreateResourceRepository(IConnection connection, string content, string message, Signature committer)
     {
-        var path = GitObjectDbFixture.GetAvailableFolderPath();
+        var path = Path.Combine(connection.Repository.Info.Path, Guid.NewGuid().ToString());
         Repository.Init(path);
 
         var repo = new Repository(path);


### PR DESCRIPTION
While comparing nodes, previous version was checking if referenced nodes were modified, badly concluding that nodes having a reference to them have changed.

This pull request improves the comparison was only checking if the path of referenced nodes have changed.