### PR TITLE
Make ITransformationComposer.Transformations a dictionary instead of a list

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -28,9 +28,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.9.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -62,7 +62,7 @@
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.3" />
     <PackageVersion Include="System.IO.Compression.ZipFile" Version="6.0.0" />
     <PackageVersion Include="System.Runtime.Caching" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="YamlDotNet" Version="15.1.2" />
   </ItemGroup>
 </Project>

--- a/src/GitObjectDb/ITransformationComposer.cs
+++ b/src/GitObjectDb/ITransformationComposer.cs
@@ -1,6 +1,6 @@
 using LibGit2Sharp;
 using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 
 namespace GitObjectDb;
 
@@ -57,8 +57,8 @@ public interface ITransformationComposer
 /// <summary>Represents a series of node transformations.</summary>
 public interface ITransformationComposerWithCommit : ITransformationComposer
 {
-    /// <summary>Gets the list of transformations.</summary>
-    IImmutableList<ITransformation> Transformations { get; }
+    /// <summary>Gets all defined transformations.</summary>
+    IReadOnlyDictionary<DataPath, ITransformation> Transformations { get; }
 
     /// <summary>Applies the transformation and store them in a new commit.</summary>
     /// <param name="description">The commit description.</param>

--- a/src/GitObjectDb/Internal/Commands/CommitCommand.cs
+++ b/src/GitObjectDb/Internal/Commands/CommitCommand.cs
@@ -31,7 +31,7 @@ internal class CommitCommand : ICommitCommand
             description.MergeParent).ToList();
         return Commit(composer.Connection,
                       info => ApplyTransformations(composer.Connection,
-                                                   composer.Transformations,
+                                                   composer.Transformations.Values,
                                                    branch?.Tip,
                                                    info.Writer,
                                                    info.Index,

--- a/src/GitObjectDb/Internal/TreeValidation.cs
+++ b/src/GitObjectDb/Internal/TreeValidation.cs
@@ -211,25 +211,12 @@ internal class TreeValidation : ITreeValidation
                 ThrowGitLinkOrResourceFolderNotExpected();
                 return;
             }
-
-            ThrowIfMixingEmbeddedAndLinkedResources(path);
         }
 
         private static void ThrowGitLinkOrResourceFolderNotExpected()
         {
             throw new GitObjectDbValidationException(
                 $"A resource folder or link was not expected to be found in a node collection.");
-        }
-
-        private void ThrowIfMixingEmbeddedAndLinkedResources(Stack<string> path)
-        {
-            var gitPath = string.Join("/", path.Reverse());
-            var module = _modules[gitPath];
-            if (module is not null)
-            {
-                throw new GitObjectDbValidationException(
-                    $"Cannot mix embedded and linked resources for the same node {gitPath}");
-            }
         }
 
         private void ValidateLinkResources(Stack<string> path)

--- a/src/tests/GitObjectDb.Tests/RemoteResourceTests.cs
+++ b/src/tests/GitObjectDb.Tests/RemoteResourceTests.cs
@@ -89,34 +89,6 @@ public class RemoteResourceTests : DisposeArguments
         }).ToList());
     }
 
-    [Test]
-    [AutoDataCustomizations(typeof(DefaultServiceProviderCustomization), typeof(SoftwareCustomization))]
-    public void CannotMixEmbeddedAndRemoteResources(IConnection connection, Application application, string content, string message, Signature committer)
-    {
-        // Arrange
-        var (path, tip) = CreateResourceRepository(connection, content, message, committer);
-
-        // Act
-        var applicationWithLinkedResources = application with
-        {
-            RemoteResource = new(path, tip),
-        };
-        var changes = connection.Update("main", c =>
-        {
-            c.CreateOrUpdate(applicationWithLinkedResources);
-            var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
-            var resource = new Resource(application,
-                                        $"Path{UniqueId.CreateNew()}",
-                                        $"File{UniqueId.CreateNew()}.txt",
-                                        new Resource.Data(stream));
-            c.CreateOrUpdate(resource);
-        });
-
-        // Assert
-        Assert.Throws<GitObjectDbValidationException>(
-            () => changes.Commit(new(message, committer, committer)));
-    }
-
     private static (string Path, string Tip) CreateResourceRepository(IConnection connection, string content, string message, Signature committer)
     {
         var path = Path.Combine(connection.Repository.Info.Path, Guid.NewGuid().ToString());


### PR DESCRIPTION
Provides several benefits:
- Can store only one transformation per path
- Faster lookup for existing path in transformations
- Internal object is no longer immutable to reduce memory pressure and is thread-safe